### PR TITLE
Make sure license file is included in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include versioneer.py
 include xyzpy/_version.py
 include README.rst
 include setup.cfg
-include LICENSE.txt
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ versionfile_source = xyzpy/_version.py
 versionfile_build = xyzpy/_version.py
 tag_prefix = ''
 parentdir_prefix = .
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The terms of the MIT license require the license text be included with all copies of the software.