### PR TITLE
Include tests and dependency lists in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include xyzpy/_version.py
 include README.rst
 include setup.cfg
 include LICENSE
+graft tests
+graft deps


### PR DESCRIPTION
This makes it easier for downstream packagers and lets them make sure they packaged the software correctly.